### PR TITLE
add PKGBUILD and workflow for DEB package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,30 @@ jobs:
       - name: Check hpk-gtk
         run: cargo check --manifest-path hpk-gtk/Cargo.toml
 
+  makedeb:
+    name: Check makedeb
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install rust
+        uses: hecrj/setup-rust-action@v1
+
+      - name: Setup Makedeb
+        run: |
+          wget -qO - 'https://proget.hunterwittenborn.com/debian-feeds/makedeb.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/makedeb-archive-keyring.gpg &> /dev/null
+          echo 'deb [signed-by=/usr/share/keyrings/makedeb-archive-keyring.gpg arch=all] https://proget.hunterwittenborn.com/ makedeb main' | sudo tee /etc/apt/sources.list.d/makedeb.list
+          sudo apt-get update
+          sudo apt-get install -y makedeb
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build hpk
+        run: cargo build --release
+
+      - name: Build DEB
+        run: makedeb -s --no-confirm
+
   nightly:
     name: Check nightly
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,30 +84,6 @@ jobs:
       - name: Check hpk-gtk
         run: cargo check --manifest-path hpk-gtk/Cargo.toml
 
-  makedeb:
-    name: Check makedeb
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Install rust
-        uses: hecrj/setup-rust-action@v1
-
-      - name: Setup Makedeb
-        run: |
-          wget -qO - 'https://proget.hunterwittenborn.com/debian-feeds/makedeb.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/makedeb-archive-keyring.gpg &> /dev/null
-          echo 'deb [signed-by=/usr/share/keyrings/makedeb-archive-keyring.gpg arch=all] https://proget.hunterwittenborn.com/ makedeb main' | sudo tee /etc/apt/sources.list.d/makedeb.list
-          sudo apt-get update
-          sudo apt-get install -y makedeb
-
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Build hpk
-        run: cargo build --release
-
-      - name: Build DEB
-        run: makedeb -s --no-confirm
-
   nightly:
     name: Check nightly
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,17 @@ jobs:
             echo "::set-output name=ASSET_CHK::$staging.tar.gz.sha256"
           fi
 
+      - name: Setup Makedeb
+        run: |
+          wget -qO - 'https://proget.hunterwittenborn.com/debian-feeds/makedeb.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/makedeb-archive-keyring.gpg &> /dev/null
+          echo 'deb [signed-by=/usr/share/keyrings/makedeb-archive-keyring.gpg arch=all] https://proget.hunterwittenborn.com/ makedeb main' | sudo tee /etc/apt/sources.list.d/makedeb.list
+          sudo apt-get update
+          sudo apt-get install -y makedeb
+
+      - name: Build DEB
+        run: |
+          makedeb -s
+
       - name: Upload package
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,16 +87,6 @@ jobs:
             echo "::set-output name=ASSET_CHK::$staging.tar.gz.sha256"
           fi
 
-      - name: Setup Makedeb
-        run: |
-          wget -qO - 'https://proget.hunterwittenborn.com/debian-feeds/makedeb.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/makedeb-archive-keyring.gpg &> /dev/null
-          echo 'deb [signed-by=/usr/share/keyrings/makedeb-archive-keyring.gpg arch=all] https://proget.hunterwittenborn.com/ makedeb main' | sudo tee /etc/apt/sources.list.d/makedeb.list
-          sudo apt-get update
-          sudo apt-get install -y makedeb
-
-      - name: Build DEB
-        run: makedeb -s --no-confirm
-
       - name: Upload package
         uses: actions/upload-release-asset@v1
         env:
@@ -116,3 +106,18 @@ jobs:
           asset_name: ${{ steps.package.outputs.ASSET_CHK }}
           asset_path: ${{ steps.package.outputs.ASSET_CHK }}
           asset_content_type: application/octet-stream
+
+  makedeb:
+    name: Build Debian package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Makedeb
+        run: |
+          wget -qO - 'https://proget.hunterwittenborn.com/debian-feeds/makedeb.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/makedeb-archive-keyring.gpg &> /dev/null
+          echo 'deb [signed-by=/usr/share/keyrings/makedeb-archive-keyring.gpg arch=all] https://proget.hunterwittenborn.com/ makedeb main' | sudo tee /etc/apt/sources.list.d/makedeb.list
+          sudo apt-get update
+          sudo apt-get install -y makedeb
+
+      - name: Build DEB
+        run: makedeb -s --no-confirm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,16 +87,6 @@ jobs:
             echo "::set-output name=ASSET_CHK::$staging.tar.gz.sha256"
           fi
 
-      - name: Setup Makedeb
-        run: |
-          wget -qO - 'https://proget.hunterwittenborn.com/debian-feeds/makedeb.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/makedeb-archive-keyring.gpg &> /dev/null
-          echo 'deb [signed-by=/usr/share/keyrings/makedeb-archive-keyring.gpg arch=all] https://proget.hunterwittenborn.com/ makedeb main' | sudo tee /etc/apt/sources.list.d/makedeb.list
-          sudo apt-get update
-          sudo apt-get install -y makedeb
-
-      - name: Build DEB
-        run: makedeb -s --no-confirm
-
       - name: Upload package
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,8 +95,7 @@ jobs:
           sudo apt-get install -y makedeb
 
       - name: Build DEB
-        run: |
-          makedeb -s
+        run: makedeb -s --no-confirm
 
       - name: Upload package
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,16 @@ jobs:
             echo "::set-output name=ASSET_CHK::$staging.tar.gz.sha256"
           fi
 
+      - name: Setup Makedeb
+        run: |
+          wget -qO - 'https://proget.hunterwittenborn.com/debian-feeds/makedeb.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/makedeb-archive-keyring.gpg &> /dev/null
+          echo 'deb [signed-by=/usr/share/keyrings/makedeb-archive-keyring.gpg arch=all] https://proget.hunterwittenborn.com/ makedeb main' | sudo tee /etc/apt/sources.list.d/makedeb.list
+          sudo apt-get update
+          sudo apt-get install -y makedeb
+
+      - name: Build DEB
+        run: makedeb -s --no-confirm
+
       - name: Upload package
         uses: actions/upload-release-asset@v1
         env:

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -23,4 +23,5 @@ package() {
     cd $srcdir/$pkgname
 
     install -D -m755 target/release/hpk -t "$pkgdir"/usr/bin
+    install -D -m644 LICENSE -t "$pkgdir/usr/share/licenses/$pkgname"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,26 @@
+# Maintainer:
+
+pkgname=hpk
+pkgver=0.3.9
+pkgrel=1
+pkgdesc="HPK archiver for Haemimont Engine game files (Tropico 3-5, Omerta, Victor Vran, Surviving Mars etc.) "
+arch=('x86_64')
+url="https://github.com/nickelc/hpk"
+license=('GPL3')
+depends=()
+makedepends=('git' 'cargo')
+
+source=("git+https://github.com/nickelc/hpk.git#tag=v$pkgver")
+sha256sums=('SKIP')
+
+build() {
+    cd $srcdir/$pkgname
+    
+    cargo build --release
+}
+
+package() {
+    cd $srcdir/$pkgname
+
+    install -D -m755 target/release/hpk -t "$pkgdir"/usr/bin
+}


### PR DESCRIPTION
PR adds a PKGBUILD file which can be used to generate a DEB for Debian / Ubuntu using makedeb or a pkg file for Arch using makepkg.

I have also updated the workflow to generate the deb file, it does not get added to the release upload, since I do not know what your naming convention for those files is.

Makedeb will generate a file called `hpk_0.3.9-1_amd64.deb` and can be easily installed using `apt install`.